### PR TITLE
Update tx in span query to inclusive overlap

### DIFF
--- a/vvhgvs/utils/altseqbuilder.py
+++ b/vvhgvs/utils/altseqbuilder.py
@@ -304,7 +304,10 @@ class AltSeqBuilder(object):
             # list is zero-based; seq pos is 1-based
             if pos.datum == Datum.CDS_START:
                 if pos.base < 0:    # 5' UTR
-                    result = cds_start - 1
+                    # This used to trim to cds_start -1 which broke dup over the
+                    # CDS start, VV works with the new code but it may break
+                    # some other use cases
+                    result = (cds_start -1) + pos.base
                 else:    # cds/intron
                     if pos.offset <= 0:
                         result = (cds_start - 1) + pos.base - 1


### PR DESCRIPTION
Update fetch transcript by span query to give all overlapping transcripts, using inclusive (1 based) coordinates.

**WARNING** 
We use this function in liftover in liftover.py and in relevant_transcripts in vvMixinConverters.py within the variantValidator code base.  This change should fix the off by one issues in this code, but it will also switch the behaviour from only returning transcripts that exceed the span of the region given (which avoids transcripts with problematic non hgvs definable changes) to all overlapping transcripts, even those without valid hgvs descriptions due to deletions outside of the transcript span.

Pete, at the very least variantValidator needs changing and checking before we decide to go ahead with this but if you think, looking at the code in these places, that a function that only returns transcripts if they exceed the span (and therefore have valid hgvs descriptions) is useful then **don't pull this** add a review comment to tell me and I can create a second function trivially. I just don't want to do unnecessary code duplication.