### PR TITLE
Add a funcion to the UTA interface to fetch seq annotation

### DIFF
--- a/vvhgvs/dataproviders/interface.py
+++ b/vvhgvs/dataproviders/interface.py
@@ -102,6 +102,8 @@ class Interface(six.with_metaclass(abc.ABCMeta, object)):
             maxsize=vvhgvs.global_config.lru_cache.maxsize, mode=self.mode, cache=self.cache)(self.get_tx_limits)
         self.get_agg_exon_aln = lru_cache(
             maxsize=vvhgvs.global_config.lru_cache.maxsize, mode=self.mode, cache=self.cache)(self.get_agg_exon_aln)
+        self.get_tx_seq_anno =lru_cache(
+                maxsize=vvhgvs.global_config.lru_cache.maxsize, mode=self.mode, cache=self.cache)(self.get_tx_seq_anno)
 
 
         def _split_version_string(v):

--- a/vvhgvs/dataproviders/uta.py
+++ b/vvhgvs/dataproviders/uta.py
@@ -192,6 +192,7 @@ class UTABase(Interface):
             from tx_exon_aln_mv where tx_ac=%s and cigar is not NULL
             """,
         "tx_seq":"select seq from seq S join seq_anno SA on S.seq_id=SA.seq_id where ac=%s",
+        "tx_seq_anno":"select len,seq_id,descr from seq_anno join seq using(seq_id) where ac=%s",
         "tx_similar":"select * from tx_similarity_v where tx_ac1 = %s",
         "tx_to_pro":"select * from associated_accessions where tx_ac = %s order by pro_ac desc",
     }
@@ -500,6 +501,12 @@ class UTABase(Interface):
             return rows[0]['pro_ac']
         except IndexError:
             return None
+
+    def get_tx_seq_anno(self,tx_ac):
+        """Return the length, checksum type seq_id, and description for a
+        transcript, in that order.
+        """
+        return self._fetchone(self._queries['tx_seq_anno'], [tx_ac])
 
     def get_assembly_map(self, assembly_name):
         """return a list of accessions for the specified assembly name (e.g., GRCh38.p5)


### PR DESCRIPTION
This is needed to avoid hitting the SeqRepo for the full sequence just to get the length in other users of this code.