### PR TITLE
Store the relative accession for transcripts

### DIFF
--- a/vvhgvs/assemblymapper.py
+++ b/vvhgvs/assemblymapper.py
@@ -91,17 +91,26 @@ class AssemblyMapper(VariantMapper):
         return self._maybe_normalize(var_out)
 
     def c_to_g(self, var_c):
-        alt_ac = self._alt_ac_for_tx_ac(var_c.ac)
+        if var_c.rel_ac:
+            alt_ac = var_c.rel_ac
+        else:
+            alt_ac = self._alt_ac_for_tx_ac(var_c.ac)
         var_out = super(AssemblyMapper, self).c_to_g(var_c, alt_ac, alt_aln_method=self.alt_aln_method)
         return self._maybe_normalize(var_out)
 
     def n_to_g(self, var_n):
-        alt_ac = self._alt_ac_for_tx_ac(var_n.ac)
+        if var_n.rel_ac:
+            alt_ac = var_n.rel_ac
+        else:
+            alt_ac = self._alt_ac_for_tx_ac(var_n.ac)
         var_out = super(AssemblyMapper, self).n_to_g(var_n, alt_ac, alt_aln_method=self.alt_aln_method)
         return self._maybe_normalize(var_out)
 
     def t_to_g(self, var_t):
-        alt_ac = self._alt_ac_for_tx_ac(var_t.ac)
+        if var_t.rel_ac:
+            alt_ac = var_t.rel_ac
+        else:
+            alt_ac = self._alt_ac_for_tx_ac(var_t.ac)
         var_out = super(AssemblyMapper, self).t_to_g(var_t, alt_ac, alt_aln_method=self.alt_aln_method)
         return self._maybe_normalize(var_out)
 

--- a/vvhgvs/normalizer.py
+++ b/vvhgvs/normalizer.py
@@ -177,11 +177,18 @@ class Normalizer(object):
                 return 0, float("inf")
             else:
                 # Get genomic sequence access number for this transcript
-                map_info = self.hdp.get_tx_mapping_options(var.ac)
-                if not map_info:
-                    raise HGVSDataNotAvailableError("No mapping info available for {ac}".format(ac=var.ac))
-                map_info = [item for item in map_info if item["alt_aln_method"] == self.alt_aln_method]
-                alt_ac = map_info[0]["alt_ac"]
+                if var.rel_ac:# transcript is already relative to a genomic ac
+                    alt_ac = var.rel_ac
+                else:
+                    map_info = self.hdp.get_tx_mapping_options(var.ac)
+                    if not map_info:
+                        raise HGVSDataNotAvailableError(
+                                "No mapping info available for {ac}".format(
+                                    ac=var.ac))
+                    map_info = [
+                            item for item in map_info if item[
+                                "alt_aln_method"] == self.alt_aln_method]
+                    alt_ac = map_info[0]["alt_ac"]
 
                 # Get tx info
                 tx_info = self.hdp.get_tx_info(var.ac, alt_ac, self.alt_aln_method)

--- a/vvhgvs/sequencevariant.py
+++ b/vvhgvs/sequencevariant.py
@@ -13,7 +13,7 @@ from vvhgvs.enums import ValidationLevel
 from vvhgvs.utils.validation import validate_type_ac_pair
 
 
-@attr.s(slots=True, repr=False)
+@attr.s(slots=True, repr=False,eq=False)
 class SequenceVariant(object):
     """
     represents a basic HGVS variant.  The only requirement is that each
@@ -23,6 +23,7 @@ class SequenceVariant(object):
     ac = attr.ib()
     type = attr.ib()
     posedit = attr.ib()
+    rel_ac = attr.ib(default='')
 
     def format(self, conf=None):
         """Formatting the stringification of sequence variants
@@ -45,6 +46,32 @@ class SequenceVariant(object):
     def __repr__(self):
         return "{0}({1})".format(self.__class__.__name__, ", ".join(
             (a.name + "=" + str(getattr(self, a.name))) for a in self.__attrs_attrs__))
+
+    def __eq__(self,other):
+        """Count transcripts with unset relative accessions as equal to any set acc
+
+        This is done so that a simple t1->g->t2 for the same tx ac will asses t1==t2 as True
+        """
+        if not isinstance(other,SequenceVariant):
+            return False
+        if self.ac != other.ac or self.type != other.type or self.posedit != other.posedit:
+            return False
+        #if self.rel_ac and other.rel_ac and self.rel_ac != other.rel_ac:
+        #    return False
+        return True
+
+    def __ne__(self,other):
+        """Count transcripts with unset relative accessions as equal to any set acc
+
+        This is done so that a simple t1->g->t2 for the same tx ac will asses t1==t2 as True
+        """
+        if not isinstance(other,SequenceVariant):
+            return True
+        if self.ac != other.ac or self.type != other.type or self.posedit != other.posedit:
+            return True
+        #if self.rel_ac and other.rel_ac and self.rel_ac != other.rel_ac:
+        return False
+
 
     def fill_ref(self, hdp):
         hm = vvhgvs.variantmapper.VariantMapper(hdp)

--- a/vvhgvs/variantmapper.py
+++ b/vvhgvs/variantmapper.py
@@ -155,7 +155,11 @@ class VariantMapper(object):
         #     pos_g = tm.n_to_g(pos_n)
         #     edit_n = vvhgvs.edit.NARefAlt(ref='', alt=self._get_altered_sequence(tm.strand, pos_g, var_g))
         # pos_n.uncertain = var_g.posedit.pos.uncertain
-        var_n = vvhgvs.sequencevariant.SequenceVariant(ac=tx_ac, type="n", posedit=vvhgvs.posedit.PosEdit(pos_n, edit_n))
+        var_n = vvhgvs.sequencevariant.SequenceVariant(
+                ac=tx_ac,
+                rel_ac=var_g.ac,
+                type="n",
+                posedit=vvhgvs.posedit.PosEdit(pos_n, edit_n))
         if self.replace_reference:
             self._replace_reference(var_n)
         return var_n
@@ -233,7 +237,11 @@ class VariantMapper(object):
         #     pos_g = tm.c_to_g(pos_c)
         #     edit_c = vvhgvs.edit.NARefAlt(ref='', alt=self._get_altered_sequence(tm.strand, pos_g, var_g))
         # pos_c.uncertain = var_g.posedit.pos.uncertain
-        var_c = vvhgvs.sequencevariant.SequenceVariant(ac=tx_ac, type="c", posedit=vvhgvs.posedit.PosEdit(pos_c, edit_c))
+        var_c = vvhgvs.sequencevariant.SequenceVariant(
+                ac=tx_ac,
+                rel_ac=var_g.ac,
+                type="c",
+                posedit=vvhgvs.posedit.PosEdit(pos_c, edit_c))
         if self.replace_reference:
             self._replace_reference(var_c)
         return var_c
@@ -304,7 +312,11 @@ class VariantMapper(object):
             edit_n = copy.deepcopy(var_c.posedit.edit)
         else:
             raise HGVSUnsupportedOperationError("Only NARefAlt/Dup/Inv types are currently implemented")
-        var_n = vvhgvs.sequencevariant.SequenceVariant(ac=var_c.ac, type="n", posedit=vvhgvs.posedit.PosEdit(pos_n, edit_n))
+        var_n = vvhgvs.sequencevariant.SequenceVariant(
+                ac=var_c.ac,
+                rel_ac=var_c.rel_ac,
+                type="n",
+                posedit=vvhgvs.posedit.PosEdit(pos_n, edit_n))
         if self.replace_reference:
             self._replace_reference(var_n)
         return var_n
@@ -332,7 +344,11 @@ class VariantMapper(object):
             edit_c = copy.deepcopy(var_n.posedit.edit)
         else:
             raise HGVSUnsupportedOperationError("Only NARefAlt/Dup/Inv types are currently implemented")
-        var_c = vvhgvs.sequencevariant.SequenceVariant(ac=var_n.ac, type="c", posedit=vvhgvs.posedit.PosEdit(pos_c, edit_c))
+        var_c = vvhgvs.sequencevariant.SequenceVariant(
+                ac=var_n.ac,
+                rel_ac=var_n.rel_ac,
+                type="c",
+                posedit=vvhgvs.posedit.PosEdit(pos_c, edit_c))
         if self.replace_reference:
             self._replace_reference(var_c)
         return var_c


### PR DESCRIPTION
This relative accession  is the origin accession for variants mapped from the genome but may also be a user specified paired reference for intronic variantion, though the parser is not updated to do this yet. This paired accession is then used in preference for intron exon boundary validation and as a default for remapping against the genome in the easy variant mapper.

Although this change is positive in most cases it does shift the behaviour of mappings enough that VV changes are needed to compensate in the cases when we *do* intend to force a remap onto the main genomic chromosomes. Since the biggest gain for this change is WRT transcripts with varying intron/exon boundaries this patch is not UTA compatible or relevant.