### PR TITLE
Calculate in place fix for poly-A CDS length issue

### DIFF
--- a/vvhgvs/utils/unusual_transcripts.py
+++ b/vvhgvs/utils/unusual_transcripts.py
@@ -1,3 +1,0 @@
-def polyadnylate():
-    return ["NM_001424184.1",
-            "ENST00000434431.2"]


### PR DESCRIPTION
This fixes the transcript oddities caused by poly-A completed CDS spans where the poly-A tail has been trimmed from the transcript, without needing a pre-generated list of affected transcripts. 

Remove the transcript oddity (by transcript ID list) handling module for now, we may have to re-add something like this in the future, but for now we can avoid it.